### PR TITLE
Converter: generating export header

### DIFF
--- a/Converter/CMakeLists.txt
+++ b/Converter/CMakeLists.txt
@@ -31,5 +31,7 @@ set(${KIT}_TARGET_LIBRARIES
 add_library(${KIT} ${${KIT}_SRCS})
 target_link_libraries(${KIT} ${${KIT}_TARGET_LIBRARIES})
 target_include_directories(${KIT} ${${KIT}_INCLUDE_DIRECTORIES})
-#TODO: Handle EXPORT_DIRECTIVE ${${KIT}_EXPORT_DIRECTIVE}
+
+include( GenerateExportHeader )
+generate_export_header( ${KIT} EXPORT_FILE_NAME ${KIT}Export.h EXPORT_MACRO_NAME ${${KIT}_EXPORT_DIRECTIVE} )
 

--- a/Converter/igtlImageConverter.h
+++ b/Converter/igtlImageConverter.h
@@ -12,10 +12,10 @@
 
 ==========================================================================*/
 
-#ifndef __igtlCodecImage_h
-#define __igtlCodecImage_h
+#ifndef __igtlImageConverter_h
+#define __igtlImageConverter_h
 
-#include "igtlSupportModuleCodecExport.h"
+#include "igtlSupportModuleConverterExport.h"
 
 // OpenIGTLink includes
 #include <igtlImageMessage.h>
@@ -34,7 +34,7 @@ namespace igtl
 /** Conversion between igtl::ImageMessage and vtk classes.
  *
  */
-class OPENIGTLINK_SUPPORT_MODULE_CODEC_EXPORT ImageConverter : public LightObject
+class OPENIGTLINK_SUPPORT_MODULE_CONVERTER_EXPORT ImageConverter : public LightObject
 {
 public:
  /** Standard class typedefs. */
@@ -79,4 +79,4 @@ protected:
 }
 
 
-#endif //__igtlCodecImage_h
+#endif //__igtlImageConverter_h


### PR DESCRIPTION
Export headers were not generated for the Converter lib and thus the lib couldn't compile because those headers are #included ( ex.: in igtlImageConverter.h : #include "igtlSupportModuleConverterExport.h" )

I used the cmake macro generate_export_header to generate the headers since I didn't want Converter lib to depend on Slicer. Let me know if this is not the proper way to do this.

 Everything compiles properly now on my Ubuntu 14.04 box.

Also: removed leftover references to old name of the Converter directory (codec).
